### PR TITLE
ユーザーとコメント間のリレーション実装

### DIFF
--- a/api/auto/data.go
+++ b/api/auto/data.go
@@ -35,15 +35,18 @@ var comments = []models.Comment{
 		ID:     1,
 		Text:   "コメントテストa00000",
 		ShopID: 1,
+		UserID: 1,
 	},
 	{
 		ID:     2,
 		Text:   "コメントテストb11111",
 		ShopID: 2,
+		UserID: 1,
 	},
 	{
 		ID:     3,
 		Text:   "コメントテストa00000-2",
 		ShopID: 1,
+		UserID: 1,
 	},
 }

--- a/api/auto/data.go
+++ b/api/auto/data.go
@@ -9,6 +9,12 @@ var users = []models.User{
 		Email:    "miku@email.com",
 		Password: "mikumiku",
 	},
+	{
+		ID:       2,
+		Nickname: "fuji",
+		Email:    "fuji@email.com",
+		Password: "fujifuji",
+	},
 }
 
 var shops = []models.Shop{
@@ -41,7 +47,7 @@ var comments = []models.Comment{
 		ID:     2,
 		Text:   "コメントテストb11111",
 		ShopID: 2,
-		UserID: 1,
+		UserID: 2,
 	},
 	{
 		ID:     3,

--- a/db/migrations/20200611153648_createComments.sql
+++ b/db/migrations/20200611153648_createComments.sql
@@ -4,6 +4,7 @@ CREATE TABLE comments (
   id int unsigned NOT NULL AUTO_INCREMENT,
   text varchar(255) NOT NULL,
   shop_id int NOT NULL,
+  user_id int NOT NULL,
   created_at timestamp NULL DEFAULT NULL,
   updated_at timestamp NULL DEFAULT NULL,
   PRIMARY KEY (id)

--- a/domain/models/Comment.go
+++ b/domain/models/Comment.go
@@ -7,6 +7,7 @@ type Comment struct {
 	ID        uint32    `json:"id"`
 	Text      string    `json:"text"`
 	ShopID    uint32    `json:"shop_id"`
+	User      User      `json:"user"`
 	UserID    uint32    `json:"user_id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/domain/models/Comment.go
+++ b/domain/models/Comment.go
@@ -7,6 +7,7 @@ type Comment struct {
 	ID        uint32    `json:"id"`
 	Text      string    `json:"text"`
 	ShopID    uint32    `json:"shop_id"`
+	UserID    uint32    `json:"user_id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/domain/repository/comment_repository.go
+++ b/domain/repository/comment_repository.go
@@ -7,4 +7,5 @@ type CommentRepository interface {
 	Save(models.Comment) (models.Comment, error)
 	Update(uint32, models.Comment) (int64, error)
 	Delete(uint32) (int64, error)
+	FindCommentUser(uint32) (models.User, error)
 }

--- a/domain/repository/shop_repository.go
+++ b/domain/repository/shop_repository.go
@@ -8,4 +8,5 @@ type ShopRepository interface {
 	Save(models.Shop) (models.Shop, error)
 	FindByID(uint32) ([]models.Comment, error)
 	SearchShop(string) (models.Shop, error)
+	FindCommentUser(uint32) (models.User, error)
 }

--- a/interfaces/handler/comment.go
+++ b/interfaces/handler/comment.go
@@ -45,7 +45,7 @@ func (ch commentHandler) HandleCommentCreate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	comment, err := ch.commentUsecase.CreateComment(requestBody.Text, requestBody.ShopID)
+	comment, err := ch.commentUsecase.CreateComment(requestBody.Text, requestBody.ShopID, requestBody.UserID)
 	if err != nil {
 		responses.ERROR(w, http.StatusInternalServerError, err)
 		return
@@ -106,6 +106,7 @@ func (ch commentHandler) HandleCommentDelete(w http.ResponseWriter, r *http.Requ
 type commentCreateRequest struct {
 	Text   string `json:"text"`
 	ShopID uint32 `json:"shop_id"`
+	UserID uint32 `json:"user_id"`
 }
 
 type commentUpdateRequest struct {

--- a/usecase/comment.go
+++ b/usecase/comment.go
@@ -8,7 +8,7 @@ import (
 
 // CommentUsecase Commentに対するUsecaseのインターフェイス
 type CommentUsecase interface {
-	CreateComment(string, uint32) (models.Comment, error)
+	CreateComment(string, uint32, uint32) (models.Comment, error)
 	UpdateComment(uint32, string) (int64, error)
 	DeleteComment(uint32) error
 }
@@ -24,10 +24,11 @@ func NewCommentUsecase(cr repository.CommentRepository) CommentUsecase {
 	}
 }
 
-func (cu commentUsecase) CreateComment(text string, sid uint32) (models.Comment, error) {
+func (cu commentUsecase) CreateComment(text string, sid, uid uint32) (models.Comment, error) {
 	comment := models.Comment{
 		Text:   text,
 		ShopID: sid,
+		UserID: uid,
 	}
 
 	err := validations.CommentValidate(&comment)
@@ -39,6 +40,14 @@ func (cu commentUsecase) CreateComment(text string, sid uint32) (models.Comment,
 	if err != nil {
 		return models.Comment{}, err
 	}
+
+	// コメントしたユーザー値を取得
+	commentUser, err := cu.commentRepository.FindCommentUser(comment.UserID)
+	if err != nil {
+		return models.Comment{}, err
+	}
+	comment.User = commentUser
+
 	return comment, nil
 }
 

--- a/usecase/shop.go
+++ b/usecase/shop.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"fmt"
 	"merpochi_server/domain/models"
 	"merpochi_server/domain/repository"
 )
@@ -72,6 +73,18 @@ func (su shopUsecase) GetShop(sid uint32) ([]models.Comment, error) {
 	comment, err := su.shopRepository.FindByID(sid)
 	if err != nil {
 		return []models.Comment{}, err
+	}
+	// コメントが存在する場合
+	if len(comment) > 0 {
+		// 取得した店舗のコメントに紐付くユーザーを取得
+		for i := 0; i < len(comment); i++ {
+			fmt.Println(comment[i])
+			commentUser, err := su.shopRepository.FindCommentUser(comment[i].UserID)
+			if err != nil {
+				return []models.Comment{}, err
+			}
+			comment[i].User = commentUser
+		}
 	}
 	return comment, nil
 }


### PR DESCRIPTION
# What
ユーザーテーブルとコメントテーブル間でリレーション(1:N)の関係を持たせるため、コメントテーブルにユーザーIDカラムを追加する。また、店舗詳細ページのコメント一覧で各ユーザーが表示されるように機能変更する。

# Why
ユーザビリティを高めるため。