### PR TITLE
infra層ユニットテスト修正 #43

### DIFF
--- a/db/migrations/20200523164215_createUsers.sql
+++ b/db/migrations/20200523164215_createUsers.sql
@@ -2,9 +2,9 @@
 -- SQL in section 'Up' is executed when this migration is applied
 CREATE TABLE users (
   id int(10) unsigned NOT NULL AUTO_INCREMENT,
-  nickname varchar(255) NOT NULL,
-  email varchar(255) NOT NULL UNIQUE,
-  password varchar(255) NOT NULL,
+  nickname varchar(20) NOT NULL,
+  email varchar(100) NOT NULL UNIQUE,
+  password varchar(40) NOT NULL,
   created_at timestamp NULL DEFAULT NULL,
   updated_at timestamp NULL DEFAULT NULL,
   PRIMARY KEY(id)

--- a/domain/repository/user_repository.go
+++ b/domain/repository/user_repository.go
@@ -8,5 +8,4 @@ type UserRepository interface {
 	FindByID(uint32) (models.User, error)
 	Update(uint32, models.User) (int64, error)
 	Delete(uint32) (int64, error)
-	SearchUser(string) error
 }

--- a/infrastructure/persistence/comment_test.go
+++ b/infrastructure/persistence/comment_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestCommentFindAll(t *testing.T) {
+func TestComment_FindAll(t *testing.T) {
 	type args struct {
 		sid uint32
 	}
@@ -71,7 +71,7 @@ func TestCommentFindAll(t *testing.T) {
 	tx.Rollback()
 }
 
-func TestCommentSave(t *testing.T) {
+func TestComment_Save(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    models.Comment
@@ -147,7 +147,7 @@ func TestCommentSave(t *testing.T) {
 	tx.Rollback()
 }
 
-func TestCommentUpdate(t *testing.T) {
+func TestComment_Update(t *testing.T) {
 	type args struct {
 		cid     uint32
 		comment models.Comment
@@ -210,7 +210,7 @@ func TestCommentUpdate(t *testing.T) {
 	tx.Rollback()
 }
 
-func TestCommentDelete(t *testing.T) {
+func TestComment_Delete(t *testing.T) {
 	type args struct {
 		cid uint32
 	}
@@ -255,7 +255,7 @@ func TestCommentDelete(t *testing.T) {
 	tx.Rollback()
 }
 
-func TestCommentFindCommentUser(t *testing.T) {
+func TestComment_FindCommentUser(t *testing.T) {
 	type args struct {
 		uid uint32
 	}

--- a/infrastructure/persistence/shop_test.go
+++ b/infrastructure/persistence/shop_test.go
@@ -34,9 +34,10 @@ func TestShop_FindCommentsCount(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewShopPersistence(db)
+			sp := NewShopPersistence(tx)
 			got := sp.FindCommentsCount(tt.args.sid)
 			// 返り値が期待しない値の場合
 			if !reflect.DeepEqual(got, tt.want) {
@@ -44,6 +45,7 @@ func TestShop_FindCommentsCount(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestShop_FindFavoritesCount(t *testing.T) {
@@ -73,9 +75,10 @@ func TestShop_FindFavoritesCount(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewShopPersistence(db)
+			sp := NewShopPersistence(tx)
 			got := sp.FindFavoritesCount(tt.args.sid)
 			// 返り値が期待しない値の場合
 			if !reflect.DeepEqual(got, tt.want) {
@@ -83,6 +86,7 @@ func TestShop_FindFavoritesCount(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestShop_Save(t *testing.T) {
@@ -163,9 +167,10 @@ func TestShop_Save(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewShopPersistence(db)
+			sp := NewShopPersistence(tx)
 			got, err := sp.Save(tt.args)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -177,6 +182,7 @@ func TestShop_Save(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestShop_Search(t *testing.T) {
@@ -219,9 +225,10 @@ func TestShop_Search(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewShopPersistence(db)
+			sp := NewShopPersistence(tx)
 			got, err := sp.Search(tt.args.code)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -234,6 +241,7 @@ func TestShop_Search(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestShop_FindCommentedShops(t *testing.T) {
@@ -278,9 +286,10 @@ func TestShop_FindCommentedShops(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewShopPersistence(db)
+			sp := NewShopPersistence(tx)
 			got, err := sp.FindCommentedShops(tt.args.uid)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -293,6 +302,7 @@ func TestShop_FindCommentedShops(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestShop_FindFavoritedShops(t *testing.T) {
@@ -337,9 +347,10 @@ func TestShop_FindFavoritedShops(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewShopPersistence(db)
+			sp := NewShopPersistence(tx)
 			got, err := sp.FindFavoritedShops(tt.args.uid)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -352,4 +363,5 @@ func TestShop_FindFavoritedShops(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }

--- a/infrastructure/persistence/shop_test.go
+++ b/infrastructure/persistence/shop_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestFindCommentsCount(t *testing.T) {
+func TestShop_FindCommentsCount(t *testing.T) {
 	type args struct {
 		sid uint32
 	}
@@ -46,7 +46,7 @@ func TestFindCommentsCount(t *testing.T) {
 	}
 }
 
-func TestFindFavoritesCount(t *testing.T) {
+func TestShop_FindFavoritesCount(t *testing.T) {
 	type args struct {
 		sid uint32
 	}
@@ -85,7 +85,7 @@ func TestFindFavoritesCount(t *testing.T) {
 	}
 }
 
-func TestShopSave(t *testing.T) {
+func TestShop_Save(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    models.Shop
@@ -179,7 +179,7 @@ func TestShopSave(t *testing.T) {
 	}
 }
 
-func TestShopSearch(t *testing.T) {
+func TestShop_Search(t *testing.T) {
 	type args struct {
 		code string
 	}
@@ -236,7 +236,7 @@ func TestShopSearch(t *testing.T) {
 	}
 }
 
-func TestFindCommentedShops(t *testing.T) {
+func TestShop_FindCommentedShops(t *testing.T) {
 	type args struct {
 		uid uint32
 	}
@@ -295,7 +295,7 @@ func TestFindCommentedShops(t *testing.T) {
 	}
 }
 
-func TestFindFavoritedShops(t *testing.T) {
+func TestShop_FindFavoritedShops(t *testing.T) {
 	type args struct {
 		uid uint32
 	}

--- a/infrastructure/persistence/shop_test.go
+++ b/infrastructure/persistence/shop_test.go
@@ -272,7 +272,7 @@ func TestShop_FindCommentedShops(t *testing.T) {
 		{
 			name: "ログインユーザーがコメントした店舗がない場合、空の値を返す",
 			args: args{
-				uid: 2,
+				uid: 3,
 			},
 			want:    []models.Shop{},
 			wantErr: false,
@@ -331,7 +331,7 @@ func TestShop_FindFavoritedShops(t *testing.T) {
 		{
 			name: "ログインユーザーがお気に入りした店舗がない場合、空の値を返す",
 			args: args{
-				uid: 2,
+				uid: 3,
 			},
 			want:    []models.Shop{},
 			wantErr: false,

--- a/infrastructure/persistence/shop_test.go
+++ b/infrastructure/persistence/shop_test.go
@@ -95,30 +95,29 @@ func TestShopSave(t *testing.T) {
 		{
 			name: "店舗情報が登録出来ること",
 			args: models.Shop{
-				ID:        2,
-				Code:      "bbbb111",
+				Code:      "cccc222",
 				Name:      "イタリアンショップ",
 				Category:  "イタリアン",
-				Opentime:  "17:00～23:00",
+				Opentime:  "18:00～23:00",
 				Budget:    2000,
-				Img:       "https://rimage.gnst.jp/rest/img/111111110000/1111.jpg",
-				Latitude:  11.111111,
-				Longitude: 11.111111,
-				URL:       "https://r.gnavi.co.jp/111111110000/?ak=bbbbbbbb",
+				Img:       "https://rimage.gnst.jp/rest/img/222222222222/2222.jpg",
+				Latitude:  22.222222,
+				Longitude: 22.222222,
+				URL:       "https://r.gnavi.co.jp/222222222222/?ak=cccccccc",
 				CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 				UpdatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			},
 			want: models.Shop{
-				ID:        2,
-				Code:      "bbbb111",
+				ID:        3,
+				Code:      "cccc222",
 				Name:      "イタリアンショップ",
 				Category:  "イタリアン",
-				Opentime:  "17:00～23:00",
+				Opentime:  "18:00～23:00",
 				Budget:    2000,
-				Img:       "https://rimage.gnst.jp/rest/img/111111110000/1111.jpg",
-				Latitude:  11.111111,
-				Longitude: 11.111111,
-				URL:       "https://r.gnavi.co.jp/111111110000/?ak=bbbbbbbb",
+				Img:       "https://rimage.gnst.jp/rest/img/222222222222/2222.jpg",
+				Latitude:  22.222222,
+				Longitude: 22.222222,
+				URL:       "https://r.gnavi.co.jp/222222222222/?ak=cccccccc",
 				CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 				UpdatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			},
@@ -127,8 +126,7 @@ func TestShopSave(t *testing.T) {
 		{
 			name: "特定の値が空でも、登録出来ること(not null)",
 			args: models.Shop{
-				ID:        3,
-				Code:      "cccc222",
+				Code:      "dddd444",
 				Name:      "",
 				Category:  "",
 				Opentime:  "",
@@ -141,8 +139,8 @@ func TestShopSave(t *testing.T) {
 				UpdatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 			},
 			want: models.Shop{
-				ID:        3,
-				Code:      "cccc222",
+				ID:        4,
+				Code:      "dddd444",
 				Name:      "",
 				Category:  "",
 				Opentime:  "",
@@ -172,7 +170,6 @@ func TestShopSave(t *testing.T) {
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
 				t.Errorf("shopPersistence.Save() error = %v, wantErr %v", err, tt.wantErr)
-				return
 			}
 			// 返り値が期待しない値の場合
 			if !reflect.DeepEqual(got, tt.want) {

--- a/infrastructure/persistence/shop_test.go
+++ b/infrastructure/persistence/shop_test.go
@@ -213,7 +213,7 @@ func TestShop_Search(t *testing.T) {
 		{
 			name: "指定した店舗コードが未登録の場合、エラーを返すこと",
 			args: args{
-				code: "dddd444",
+				code: "eeee555",
 			},
 			want:    models.Shop{},
 			wantErr: true,

--- a/infrastructure/persistence/test_data.go
+++ b/infrastructure/persistence/test_data.go
@@ -7,13 +7,11 @@ import (
 
 var users = []models.User{
 	{
-		ID:       1,
 		Nickname: "miku",
 		Email:    "miku@email.com",
 		Password: "mikumiku",
 	},
 	{
-		ID:       2,
 		Nickname: "taka",
 		Email:    "taka@email.com",
 		Password: "takataka",
@@ -31,6 +29,19 @@ var shops = []models.Shop{
 		Latitude:  00.000000,
 		Longitude: 00.000000,
 		URL:       "https://r.gnavi.co.jp/000000000000/?ak=aaaaaaaa",
+		CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
+		UpdatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
+	},
+	{
+		Code:      "bbbb000",
+		Name:      "海鮮居酒屋",
+		Category:  "海鮮",
+		Opentime:  "16:00～23:00",
+		Budget:    4000,
+		Img:       "https://rimage.gnst.jp/rest/img/111111111111/1111.jpg",
+		Latitude:  11.111111,
+		Longitude: 11.111111,
+		URL:       "https://r.gnavi.co.jp/111111111111/?ak=bbbbbbbb",
 		CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 		UpdatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local),
 	},

--- a/infrastructure/persistence/test_data.go
+++ b/infrastructure/persistence/test_data.go
@@ -16,6 +16,11 @@ var users = []models.User{
 		Email:    "taka@email.com",
 		Password: "takataka",
 	},
+	{
+		Nickname: "enako",
+		Email:    "enako@email.com",
+		Password: "enaena",
+	},
 }
 
 var shops = []models.Shop{

--- a/infrastructure/persistence/user.go
+++ b/infrastructure/persistence/user.go
@@ -115,25 +115,3 @@ func (up *userPersistence) Delete(uid uint32) (int64, error) {
 	}
 	return 0, rs.Error
 }
-
-// SearchUser 指定メールアドレスのユーザーを検索(無い場合にtrue)
-func (up *userPersistence) SearchUser(email string) error {
-	var err error
-
-	user := models.User{}
-	done := make(chan bool)
-
-	go func(ch chan<- bool) {
-		defer close(ch)
-		err = up.db.Debug().Model(&models.User{}).Where("email = ?", email).Take(&user).Error
-		if err != nil {
-			ch <- true
-			return
-		}
-		ch <- false
-	}(done)
-	if channels.OK(done) {
-		return nil
-	}
-	return errors.New("このメールアドレスは既に使用されています")
-}

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSave(t *testing.T) {
+func TestUser_Save(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    models.User
@@ -46,7 +46,7 @@ func TestSave(t *testing.T) {
 	}
 }
 
-func TestFindByID(t *testing.T) {
+func TestUser_FindByID(t *testing.T) {
 	type args struct {
 		uid uint32
 	}
@@ -94,7 +94,7 @@ func TestFindByID(t *testing.T) {
 	}
 }
 
-func TestUpdate(t *testing.T) {
+func TestUser_Update(t *testing.T) {
 	type args struct {
 		uid  uint32
 		user models.User
@@ -145,7 +145,7 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
-func TestDelete(t *testing.T) {
+func TestUser_Delete(t *testing.T) {
 	type args struct {
 		uid uint32
 	}
@@ -189,7 +189,7 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func TestSearchUser(t *testing.T) {
+func TestUser_SearchUser(t *testing.T) {
 	type args struct {
 		email string
 	}

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -292,37 +292,3 @@ func TestUser_Delete(t *testing.T) {
 		})
 	}
 }
-
-func TestUser_SearchUser(t *testing.T) {
-	type args struct {
-		email string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "指定したメールアドレスの重複が無いこと",
-			args: args{
-				email: "enako@email.com",
-			},
-			wantErr: false,
-		},
-		{
-			name: "指定したメールアドレスが重複していること",
-			args: args{
-				email: "fuji@email.com",
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			up := NewUserPersistence(db)
-			if err := up.SearchUser(tt.args.email); (err != nil) != tt.wantErr {
-				t.Errorf("userPersistence.SearchUser() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -166,18 +166,62 @@ func TestUser_Update(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "指定したユーザー情報を更新出来ること",
+			name: "変更するニックネームが20文字以内の場合、更新出来ること",
 			args: args{
 				uid: 1,
 				user: models.User{
-					Email: "mikumiku@email.com",
+					Nickname: strings.Repeat("b", 20),
 				},
 			},
 			want:    1,
 			wantErr: false,
 		},
 		{
-			name: "指定したユーザー情報がない時は更新出来ないこと",
+			name: "変更するニックネームが21文字以上の場合、更新出来ないこと",
+			args: args{
+				uid: 2,
+				user: models.User{
+					Nickname: strings.Repeat("b", 21),
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "変更するメールアドレスが100文字以内の場合、更新出来ること",
+			args: args{
+				uid: 1,
+				user: models.User{
+					Email: strings.Repeat("a", 90) + "@email.com", // 100文字
+				},
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "変更するメールアドレスが101文字以上の場合、更新出来ないこと",
+			args: args{
+				uid: 2,
+				user: models.User{
+					Email: strings.Repeat("a", 91) + "@email.com", // 101文字
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "変更するメールアドレスが重複している場合、更新出来ないこと",
+			args: args{
+				uid: 3,
+				user: models.User{
+					Email: "taka@email.com",
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "指定したユーザーIDが存在しない場合、更新出来ないこと",
 			args: args{
 				uid: 10,
 				user: models.User{

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"merpochi_server/domain/models"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -14,19 +15,80 @@ func TestUser_Save(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "ユーザー情報の保存処理が正常に行われること",
+			name: "ニックネームが20文字以内の場合、登録出来ること",
 			args: models.User{
-				ID:       3,
-				Nickname: "fujisawatk",
-				Email:    "fuji@email.com",
-				Password: "fujifuji0707",
+				Nickname: strings.Repeat("a", 20),
+				Email:    "test1@email.com",
+				Password: "testpassword",
 			},
 			want: models.User{
-				Nickname: "fujisawatk",
-				Email:    "fuji@email.com",
-				Password: "fujifuji0707",
+				Email: "test1@email.com",
 			},
 			wantErr: false,
+		},
+		{
+			name: "ニックネームが21文字以上の場合、登録出来ないこと",
+			args: models.User{
+				Nickname: strings.Repeat("a", 21),
+				Email:    "test2@email.com",
+				Password: "testpassword",
+			},
+			want:    models.User{},
+			wantErr: true,
+		},
+		{
+			name: "メールアドレスが100文字以内の場合、登録出来ること",
+			args: models.User{
+				Nickname: "testname",
+				Email:    strings.Repeat("a", 90) + "@email.com", // 100文字
+				Password: "testpassword",
+			},
+			want: models.User{
+				Email: strings.Repeat("a", 90) + "@email.com", // 100文字
+			},
+			wantErr: false,
+		},
+		{
+			name: "メールアドレスが101文字以上の場合、登録出来ないこと",
+			args: models.User{
+				Nickname: "testname",
+				Email:    strings.Repeat("b", 91) + "@email.com", // 101文字
+				Password: "testpassword",
+			},
+			want:    models.User{},
+			wantErr: true,
+		},
+		{
+			name: "メールアドレスが重複している場合、登録出来ないこと",
+			args: models.User{
+				Nickname: "testname",
+				Email:    "miku@email.com",
+				Password: "testpassword",
+			},
+			want:    models.User{},
+			wantErr: true,
+		},
+		{
+			name: "パスワードが40文字以内の場合、登録出来ること",
+			args: models.User{
+				Nickname: "testname",
+				Email:    "test3@email.com",
+				Password: strings.Repeat("a", 40),
+			},
+			want: models.User{
+				Email: "test3@email.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "パスワードが41文字以上の場合、登録出来ないこと",
+			args: models.User{
+				Nickname: "testname",
+				Email:    "fuji4@email.com",
+				Password: strings.Repeat("b", 41),
+			},
+			want:    models.User{},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -91,9 +91,10 @@ func TestUser_Save(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			up := NewUserPersistence(db)
+			up := NewUserPersistence(tx)
 			got, err := up.Save(tt.args)
 			if (err != nil) != tt.wantErr {
 				// 予期しないエラーの場合
@@ -106,6 +107,7 @@ func TestUser_Save(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestUser_FindByID(t *testing.T) {
@@ -137,9 +139,10 @@ func TestUser_FindByID(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			up := NewUserPersistence(db)
+			up := NewUserPersistence(tx)
 			got, err := up.FindByID(tt.args.uid)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -152,6 +155,7 @@ func TestUser_FindByID(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestUser_Update(t *testing.T) {
@@ -232,9 +236,10 @@ func TestUser_Update(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			up := NewUserPersistence(db)
+			up := NewUserPersistence(tx)
 			got, err := up.Update(tt.args.uid, tt.args.user)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -247,6 +252,7 @@ func TestUser_Update(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }
 
 func TestUser_Delete(t *testing.T) {
@@ -276,9 +282,10 @@ func TestUser_Delete(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	tx := db.Begin()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			up := NewUserPersistence(db)
+			up := NewUserPersistence(tx)
 			got, err := up.Delete(tt.args.uid)
 			// 予期しないエラーの場合
 			if (err != nil) != tt.wantErr {
@@ -291,4 +298,5 @@ func TestUser_Delete(t *testing.T) {
 			}
 		})
 	}
+	tx.Rollback()
 }

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -129,13 +129,11 @@ func TestUser_FindByID(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "指定したユーザー情報がない時にエラーを返すこと",
+			name: "指定したユーザー情報がない場合、エラーを返すこと",
 			args: args{
 				uid: 10,
 			},
-			want: models.User{
-				Email: "",
-			},
+			want:    models.User{},
 			wantErr: true,
 		},
 	}

--- a/usecase/user.go
+++ b/usecase/user.go
@@ -38,12 +38,6 @@ func (uu userUsecase) CreateUser(nickname, email, password string) (models.User,
 		return models.User{}, err
 	}
 
-	// メールアドレスの重複確認
-	err = uu.userRepository.SearchUser(user.Email)
-	if err != nil {
-		return models.User{}, err
-	}
-
 	// パスワードのハッシュ化
 	var hashedPassword []byte
 	hashedPassword, err = security.Hash(user.Password)


### PR DESCRIPTION
# What
①テスト関数毎にテストデータをリセットするため、トランザクションを追加する。
②店舗情報のテストデータを追加する。
③テスト関数の名称を統一性のあるものに変更する。

# Why
①テストデータの依存をなくすため。
②他機能のテストに必要なため。
③可読性を向上させるため。