### PR TITLE
ユーザーテーブルのパスワード文字数修正 #53

### DIFF
--- a/db/migrations/20200523164215_createUsers.sql
+++ b/db/migrations/20200523164215_createUsers.sql
@@ -4,7 +4,7 @@ CREATE TABLE users (
   id int(10) unsigned NOT NULL AUTO_INCREMENT,
   nickname varchar(20) NOT NULL,
   email varchar(100) NOT NULL UNIQUE,
-  password varchar(40) NOT NULL,
+  password varchar(60) NOT NULL,
   created_at timestamp NULL DEFAULT NULL,
   updated_at timestamp NULL DEFAULT NULL,
   PRIMARY KEY(id)

--- a/infrastructure/persistence/user_test.go
+++ b/infrastructure/persistence/user_test.go
@@ -69,11 +69,11 @@ func TestUser_Save(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "パスワードが40文字以内の場合、登録出来ること",
+			name: "パスワードが60文字以内の場合、登録出来ること",
 			args: models.User{
 				Nickname: "testname",
 				Email:    "test3@email.com",
-				Password: strings.Repeat("a", 40),
+				Password: strings.Repeat("a", 60),
 			},
 			want: models.User{
 				Email: "test3@email.com",
@@ -81,11 +81,11 @@ func TestUser_Save(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "パスワードが41文字以上の場合、登録出来ないこと",
+			name: "パスワードが61文字以上の場合、登録出来ないこと",
 			args: models.User{
 				Nickname: "testname",
 				Email:    "fuji4@email.com",
-				Password: strings.Repeat("b", 41),
+				Password: strings.Repeat("b", 61),
 			},
 			want:    models.User{},
 			wantErr: true,


### PR DESCRIPTION
# What
ユーザー情報を格納するテーブルのパスワード文字列数が、ハッシュ化されたパスワードを保存できる許容値でなかったため、修正する。

# Why
不具合修正。