### PR TITLE
投稿機能ユーザー値追加 #80

### DIFF
--- a/api/auto/data.go
+++ b/api/auto/data.go
@@ -1,6 +1,8 @@
 package auto
 
-import "merpochi_server/domain/models"
+import (
+	"merpochi_server/domain/models"
+)
 
 var users = []models.User{
 	{
@@ -112,15 +114,19 @@ var posts = []models.Post{
 		UserID: 1,
 	},
 	{
-		ID:     2,
-		Text:   "また行きたい！！",
+		ID: 2,
+		Text: "有名で、人気のお店(チェーン)ですね。地方では見かけませんが。\n" +
+			"会社の同僚と何度か伺っています。店内はお客さんでいっぱいでも、注文して→スムーズに提供してくれます。\n" +
+			"串のサイズ感はやや大きめで、食べごたえもあり、美味しいと思います。\n" +
+			"串以外も(食べた中で)鳥の酢モノや鳥ご飯が美味しいと思います。",
 		Rating: 4,
 		ShopID: 2,
 		UserID: 2,
 	},
 	{
-		ID:     3,
-		Text:   "まあまあ！！",
+		ID: 3,
+		Text: "昔、名古屋にいた時に遅くまでやっているのと全てがほぼ均一で安かったので夜食代わりによく行っていた鳥貴族。\n" +
+			"鶴見にもあったので軽く二軒目ということで入ってみた。いい意味でも悪い意味でも雰囲気も含め均一だった（笑）",
 		Rating: 3,
 		ShopID: 2,
 		UserID: 1,

--- a/domain/repository/post_repository.go
+++ b/domain/repository/post_repository.go
@@ -9,5 +9,6 @@ type PostRepository interface {
 	FindByID(uint32, uint32) (*models.Post, error)
 	Update(*models.Post) (int64, error)
 	Delete(uint32) error
+	FindByUserID(uint32) (*models.User, error)
 	FindCommentsCount(uint32) uint32
 }

--- a/infrastructure/router/routes/posts_routes.go
+++ b/infrastructure/router/routes/posts_routes.go
@@ -11,7 +11,8 @@ import (
 func iniPostsRoutes() []Route {
 	// 依存関係を注入
 	postPersistence := persistence.NewPostPersistence(database.DB)
-	postUsecase := usecase.NewPostUsecase(postPersistence)
+	imagePersistence := persistence.NewImagePersistence(database.DB)
+	postUsecase := usecase.NewPostUsecase(postPersistence, imagePersistence)
 	postHandler := handler.NewPostHandler(postUsecase)
 
 	postRoutes := []Route{

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -57,6 +57,10 @@ func (pu *postUsecase) GetPosts(sid uint32) ([]postsResponse, error) {
 	if len(*posts) > 0 {
 		// 投稿のコメント数を取得
 		for i := 0; i < len(*posts); i++ {
+			user, err := pu.postRepository.FindByUserID((*posts)[i].UserID)
+			if err != nil {
+				return []postsResponse{}, err
+			}
 			commentsCount := pu.postRepository.FindCommentsCount((*posts)[i].ID)
 			if err != nil {
 				return []postsResponse{}, err
@@ -66,6 +70,7 @@ func (pu *postUsecase) GetPosts(sid uint32) ([]postsResponse, error) {
 				Text:          (*posts)[i].Text,
 				Rating:        (*posts)[i].Rating,
 				UserID:        (*posts)[i].UserID,
+				UserNickname:  (*user).Nickname,
 				CommentsCount: commentsCount,
 			}
 			responses = append(responses, res)
@@ -114,5 +119,6 @@ type postsResponse struct {
 	Text          string `json:"text"`
 	Rating        uint32 `json:"rating"`
 	UserID        uint32 `json:"user_id"`
+	UserNickname  string `json:"user_nickname"`
 	CommentsCount uint32 `json:"comments_count"`
 }

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -83,6 +83,14 @@ func (pu *postUsecase) GetPosts(sid uint32) ([]postsResponse, error) {
 			if err != nil {
 				return []postsResponse{}, err
 			}
+			// 投稿作成or編集時刻設定
+			var time string
+			format1 := "2006/01/02 15:04:05"
+			if (*posts)[i].CreatedAt != (*posts)[i].UpdatedAt {
+				time = "編集済 " + ((*posts)[i].UpdatedAt).Format(format1)
+			} else {
+				time = ((*posts)[i].CreatedAt).Format(format1)
+			}
 
 			res := postsResponse{
 				ID:            (*posts)[i].ID,
@@ -92,6 +100,7 @@ func (pu *postUsecase) GetPosts(sid uint32) ([]postsResponse, error) {
 				UserNickname:  (*user).Nickname,
 				UserImage:     uri,
 				CommentsCount: commentsCount,
+				Time:          time,
 			}
 			responses = append(responses, res)
 		}
@@ -142,4 +151,5 @@ type postsResponse struct {
 	UserNickname  string `json:"user_nickname"`
 	UserImage     string `json:"user_image"`
 	CommentsCount uint32 `json:"comments_count"`
+	Time          string `json:"time"`
 }

--- a/util/security/encode.go
+++ b/util/security/encode.go
@@ -1,0 +1,16 @@
+package security
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+)
+
+// Base64EncodeToString base64エンコードの文字列生成
+func Base64EncodeToString(buf *bytes.Buffer) (string, error) {
+	data, err := ioutil.ReadAll(buf)
+	mine := http.DetectContentType(data)
+	uri := "data:" + mine + ";base64," + base64.StdEncoding.EncodeToString(data)
+	return uri, err
+}


### PR DESCRIPTION
# What
投稿機能のモデルにユーザー構造体を設定する。また、レスポンス値にbase64エンコード文字列の画像データも追加し、フロント側に投稿機能に紐づくユーザー値をレスポンスできるように、機能追加する。

# What
想定のUI実装に必要なため。
ユーザビリティを高めるため。