### PR TITLE
コメント保存機能ユーザー値追加 #84

### DIFF
--- a/infrastructure/router/routes/comments_routes.go
+++ b/infrastructure/router/routes/comments_routes.go
@@ -11,7 +11,15 @@ import (
 func iniCommentsRoutes() []Route {
 	// 依存関係を注入
 	commentPersistence := persistence.NewCommentPersistence(database.DB)
-	commentUsecase := usecase.NewCommentUsecase(commentPersistence)
+	userPersistence := persistence.NewUserPersistence(database.DB)
+	postPersistence := persistence.NewPostPersistence(database.DB)
+	imagePersistence := persistence.NewImagePersistence(database.DB)
+	commentUsecase := usecase.NewCommentUsecase(
+		commentPersistence,
+		userPersistence,
+		postPersistence,
+		imagePersistence,
+	)
 	commentHandler := handler.NewCommentHandler(commentUsecase)
 
 	commentRoutes := []Route{

--- a/usecase/comment.go
+++ b/usecase/comment.go
@@ -4,24 +4,37 @@ import (
 	"merpochi_server/domain/models"
 	"merpochi_server/domain/repository"
 	"merpochi_server/usecase/validations"
+	"merpochi_server/util/security"
+	"time"
 )
 
 // CommentUsecase Commentに対するUsecaseのインターフェイス
 type CommentUsecase interface {
 	GetComments(uint32) (*[]models.Comment, error)
-	CreateComment(string, uint32, uint32) (*models.Comment, error)
+	CreateComment(string, uint32, uint32) (createCommentResponse, error)
 	UpdateComment(uint32, string) (int64, error)
 	DeleteComment(uint32) error
 }
 
 type commentUsecase struct {
 	commentRepository repository.CommentRepository
+	userRepository    repository.UserRepository // belongs to
+	postRepository    repository.PostRepository // belongs to
+	imageRepository   repository.ImageRepository
 }
 
 // NewCommentUsecase Commentデータに関するUsecaseを生成
-func NewCommentUsecase(cr repository.CommentRepository) CommentUsecase {
+func NewCommentUsecase(
+	cr repository.CommentRepository,
+	ur repository.UserRepository,
+	pr repository.PostRepository,
+	ir repository.ImageRepository,
+) CommentUsecase {
 	return &commentUsecase{
 		commentRepository: cr,
+		userRepository:    ur,
+		postRepository:    pr,
+		imageRepository:   ir,
 	}
 }
 
@@ -44,7 +57,7 @@ func (cu *commentUsecase) GetComments(pid uint32) (*[]models.Comment, error) {
 	return comments, nil
 }
 
-func (cu *commentUsecase) CreateComment(text string, uid, pid uint32) (*models.Comment, error) {
+func (cu *commentUsecase) CreateComment(text string, uid, pid uint32) (createCommentResponse, error) {
 	comment := &models.Comment{
 		Text:   text,
 		UserID: uid,
@@ -53,21 +66,28 @@ func (cu *commentUsecase) CreateComment(text string, uid, pid uint32) (*models.C
 
 	err := validations.CommentValidate(comment)
 	if err != nil {
-		return &models.Comment{}, err
+		return createCommentResponse{}, err
 	}
 
 	err = cu.commentRepository.Save(comment)
 	if err != nil {
-		return &models.Comment{}, err
+		return createCommentResponse{}, err
 	}
 
-	user, err := cu.commentRepository.FindByUserID(comment.UserID)
+	commentedUser, imgURI, time, err := cu.GetUserData((*comment).UserID, (*comment).CreatedAt, (*comment).UpdatedAt)
 	if err != nil {
-		return &models.Comment{}, err
+		return createCommentResponse{}, err
 	}
-	comment.User = *user
+	res := createCommentResponse{
+		ID:           (*comment).ID,
+		Text:         (*comment).Text,
+		UserID:       (*comment).UserID,
+		UserNickname: commentedUser,
+		UserImage:    imgURI,
+		Time:         time,
+	}
 
-	return comment, nil
+	return res, nil
 }
 
 func (cu *commentUsecase) UpdateComment(cid uint32, text string) (int64, error) {
@@ -93,4 +113,54 @@ func (cu *commentUsecase) DeleteComment(cid uint32) error {
 		return err
 	}
 	return nil
+}
+
+// ユーザー情報取得〜整形まで
+func (cu *commentUsecase) GetUserData(uid uint32, createdAt, updatedAt time.Time) (string, string, string, error) {
+	user, err := cu.userRepository.FindByID(uid)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	imgURI, err := cu.GetUserImage(uid)
+	if err != nil {
+		return "", "", "", err
+	}
+	// 作成or編集時刻整形
+	var time string
+	format1 := "2006/01/02 15:04:05"
+	if createdAt != updatedAt {
+		time = "編集済 " + (updatedAt).Format(format1)
+	} else {
+		time = (createdAt).Format(format1)
+	}
+	return user.Nickname, imgURI, time, nil
+}
+
+// ユーザー画像取得〜base64エンコード文字列生成まで
+func (cu *commentUsecase) GetUserImage(uid uint32) (string, error) {
+	img, err := cu.imageRepository.FindByID(uid)
+	if err != nil {
+		return "", err
+	}
+
+	err = cu.imageRepository.DownloadS3(img)
+	if err != nil {
+		return "", err
+	}
+
+	uri, err := security.Base64EncodeToString(img.Buf)
+	if err != nil {
+		return "", err
+	}
+	return uri, nil
+}
+
+type createCommentResponse struct {
+	ID           uint32 `json:"id"`
+	Text         string `json:"text"`
+	UserID       uint32 `json:"user_id"`
+	UserNickname string `json:"user_nickname"`
+	UserImage    string `json:"user_image"`
+	Time         string `json:"time"`
 }

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -19,7 +19,7 @@ type PostUsecase interface {
 
 type postUsecase struct {
 	postRepository    repository.PostRepository
-	commentRepository repository.CommentRepository
+	commentRepository repository.CommentRepository // has many
 	imageRepository   repository.ImageRepository
 }
 


### PR DESCRIPTION
# What
コメント保存時、レスポンスにユーザーネーム、ユーザー画像、作成（編集）日付を追加して、アプリ側で表示できるように変更を加える。

# Why
ユーザビリティを高めるため。